### PR TITLE
Restore correct chatlog link tab behavior pre-#11.

### DIFF
--- a/static/js/links.js
+++ b/static/js/links.js
@@ -37,6 +37,7 @@ function linkChunkToElement(chunk, server) {
 		newAnchor.className = 'chatlogLink';
 		newAnchor.href = url;
 		newAnchor.target = '_blank';
+		newAnchor.tabIndex = -1;
 
 		return newAnchor;
 	}


### PR DESCRIPTION
In #11, the element used for links was changed to anchor. This indadvertedly changed how tabs work, since anchor elements are selectable via tab by default, making it harder to get to chat box. This fix restores the previous intended behavior.
