### PR TITLE
Override title for chatlog links.

### DIFF
--- a/static/js/links.js
+++ b/static/js/links.js
@@ -35,6 +35,7 @@ function linkChunkToElement(chunk, server) {
 		newAnchor.appendChild(document.createTextNode(label));
 
 		newAnchor.className = 'chatlogLink';
+		newAnchor.title = url;
 		newAnchor.href = url;
 		newAnchor.target = '_blank';
 		newAnchor.tabIndex = -1;


### PR DESCRIPTION
Makes the tooltip that appears when hovering over a link to show the target url, rather than the misleading date when underlying message was sent.

An example of current behavior:

![image](https://cloud.githubusercontent.com/assets/1924134/2869634/d58887de-d27e-11e3-80c5-12f18297fa91.png)

The vast majority of links on the internet have a title relevant to the destination, rather than the source. This PR fixes that.
