### PR TITLE
Fix notifications by migrating to standardized Web API.

### DIFF
--- a/static/js/statechanges.js
+++ b/static/js/statechanges.js
@@ -528,9 +528,12 @@ var sc = {
 			return ~text.toLowerCase().split(/[^\w\d]+/).indexOf(nick.toLowerCase());
 		},
 		notify: function(icon, title, text, entityId) {
-			if (typeof window === 'object' && window.webkitNotifications) {
-				if (window.webkitNotifications.checkPermission() === 0) {
-					var notification = window.webkitNotifications.createNotification(icon, title, text);
+			if (typeof window === 'object' && window.Notification) {
+				if (window.Notification.permission === 'granted') {
+					var notification = new window.Notification(title, {
+						body: text,
+						icon: icon
+					});
 
 					notification.onclick = function() {
 						if (typeof g_requestSetActiveEntity === 'function') {
@@ -540,13 +543,11 @@ var sc = {
 						window.focus();
 					}
 
-					notification.show();
-
 					setTimeout(function() {
-						notification.cancel();
+						notification.close();
 					}, 6000);
 				} else {
-					window.webkitNotifications.requestPermission();
+					window.Notification.requestPermission();
 				}
 			}
 		},

--- a/static/js/webirc.js
+++ b/static/js/webirc.js
@@ -12,8 +12,8 @@ webircApp.directive('loginbox', function($rootScope) {
 					password: scope.password
 				});
 
-				if (window.webkitNotifications && window.webkitNotifications.checkPermission() !== 0) {
-					window.webkitNotifications.requestPermission();
+				if (window.Notification && window.Notification.permission !== 'granted') {
+					window.Notification.requestPermission();
 				}
 			};
 


### PR DESCRIPTION
Recently, Chrome has been updated on stable channel, removing the legacy non-standard `webkitNotifications` support.

https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/8vqyfHa8_dw

That broke notifications in WebIRC on Chrome. It still works on current Safari.

This PR updates to new standardized Web API for notifications. I used [these docs](https://developer.mozilla.org/en-US/docs/Web/API/notification) as reference.

**With that, notifications work once again in Chrome, and they continue to work in Safari as well.**

---

A nice summary of the notifications API situation from http://kenneth.io/blog/2013/07/15/the-messy-state-of-web-notifications-in-chrome-safari-blink-webkit/:

> - 24-10-2013: The previous linked bugs in Chrome has been fixed. Web Notifications now work as expected. Disregard this article.
> - 03-03-2014: Chrome is about to remove the legacy Web Notifications API from Chrome M35 (Stable @ May 20 2014). Read the [intent to remove](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/8vqyfHa8_dw).

---

Note that this is a MVP PR that restores previous functionality. It's possible to improve it by adding support for `Notification.permission === "denied"` case. I'm not sure how to best handle it: do we simply give up and not try to `requestPermission()`, or alert the user somehow that they need to allow notifications if they want to see them? It would be bad to bug the user if they are already aware and disabled the notifications on purpose. So it'd be very hard to improve over the current behavior: don't do anything special for `Notification.permission === "denied"` case.
